### PR TITLE
Add cow vaults

### DIFF
--- a/src/lib/vault-list.ts
+++ b/src/lib/vault-list.ts
@@ -28,7 +28,7 @@ async function fetchVaults() {
         };
     };
 
-    const vaultResponse = await axios.get<ApiBeefyVaultResponse>(`${BEEFY_API_URL}/vaults`);
+    const vaultResponse = await axios.get<ApiBeefyVaultResponse>(`${BEEFY_API_URL}/harvestable-vaults`);
     const rawVaults = vaultResponse.data;
 
     const tvlResponse = await axios.get<ApiBeefyTvlResponse>(`${BEEFY_API_URL}/tvl`);


### PR DESCRIPTION
@prevostc This just swaps the endpoint vaults are pulled from to one that includes both standard vaults and clm vaults. As far as I could tell cowllector doesn't depend on anything that is on a standard vault but not on a clm vault.

Needs https://github.com/beefyfinance/beefy-api/pull/1405 to be merged